### PR TITLE
Update sprayer.py

### DIFF
--- a/CMP9767M/uol_cmp9767m_base/scripts/sprayer.py
+++ b/CMP9767M/uol_cmp9767m_base/scripts/sprayer.py
@@ -3,6 +3,7 @@
 import rospy
 from gazebo_msgs.srv import SpawnModel, SpawnModelRequest
 from std_srvs.srv import Empty
+from std_msgs.msg import String
 from uuid import uuid4
 
 BOX_SDF="""
@@ -48,30 +49,109 @@ BOX_SDF="""
 
 
 class Sprayer:
-
+    # The request.initial_pose.position.y is the distance from the center of the sprayer
     def __init__(self):
         self.sdf = BOX_SDF
-        rospy.Service('spray', Empty, self.spray)
+        #define the services
+        rospy.Service('spray1', Empty, self.spray1)
+        rospy.Service('spray2', Empty, self.spray2)
+        rospy.Service('spray3', Empty, self.spray3)
+        rospy.Service('spray4', Empty, self.spray4)
+        rospy.Service('spray5', Empty, self.spray5)
+        rospy.Service('spray6', Empty, self.spray6)
+        rospy.Service('spray7', Empty, self.spray7)
+
+        #call the service to spawn a little rectangle on gazebo
         self.spawner = rospy.ServiceProxy(
             '/gazebo/spawn_sdf_model', SpawnModel)
 
-    def spray(self, r):
+
+    def spray1(self, r):
+   
         request = SpawnModelRequest()
         request.model_name = 'killbox_%s' % uuid4()
         request.model_xml = self.sdf
         request.reference_frame = 'thorvald_001/base_link'
         request.initial_pose.position.z = 0.005
         request.initial_pose.position.x = -0.45
+        request.initial_pose.position.y = 0.3
         request.initial_pose.orientation.w = 1.0
         self.spawner(request)
         return []
 
+    def spray2(self, r):
+        request = SpawnModelRequest()
+        request.model_name = 'killbox_%s' % uuid4()
+        request.model_xml = self.sdf
+        request.reference_frame = 'thorvald_001/base_link'
+        request.initial_pose.position.z = 0.005
+        request.initial_pose.position.x = -0.45
+        request.initial_pose.position.y = 0.2
+        request.initial_pose.orientation.w = 1.0
+        self.spawner(request)
+        return []
+
+    def spray3(self, r):
+        request = SpawnModelRequest()
+        request.model_name = 'killbox_%s' % uuid4()
+        request.model_xml = self.sdf
+        request.reference_frame = 'thorvald_001/base_link'
+        request.initial_pose.position.z = 0.005
+        request.initial_pose.position.x = -0.45
+        request.initial_pose.position.y = 0.1
+        request.initial_pose.orientation.w = 1.0
+        self.spawner(request)
+        return []
+
+    def spray4(self, r):
+        request = SpawnModelRequest()
+        request.model_name = 'killbox_%s' % uuid4()
+        request.model_xml = self.sdf
+        request.reference_frame = 'thorvald_001/base_link'
+        request.initial_pose.position.z = 0.005
+        request.initial_pose.position.x = -0.45
+        request.initial_pose.position.y = 0
+        request.initial_pose.orientation.w = 1.0
+        self.spawner(request)
+        return []
+
+    def spray5(self, r):
+        request = SpawnModelRequest()
+        request.model_name = 'killbox_%s' % uuid4()
+        request.model_xml = self.sdf
+        request.reference_frame = 'thorvald_001/base_link'
+        request.initial_pose.position.z = 0.005
+        request.initial_pose.position.x = -0.45
+        request.initial_pose.position.y = -0.1
+        request.initial_pose.orientation.w = 1.0
+        self.spawner(request)
+        return []
+
+    def spray6(self, r):
+        request = SpawnModelRequest()
+        request.model_name = 'killbox_%s' % uuid4()
+        request.model_xml = self.sdf
+        request.reference_frame = 'thorvald_001/base_link'
+        request.initial_pose.position.z = 0.005
+        request.initial_pose.position.x = -0.45
+        request.initial_pose.position.y = -0.2
+        request.initial_pose.orientation.w = 1.0
+        self.spawner(request)
+        return []
+
+    def spray7(self, r):
+        request = SpawnModelRequest()
+        request.model_name = 'killbox_%s' % uuid4()
+        request.model_xml = self.sdf
+        request.reference_frame = 'thorvald_001/base_link'
+        request.initial_pose.position.z = 0.005
+        request.initial_pose.position.x = -0.45
+        request.initial_pose.position.y = -0.3
+        request.initial_pose.orientation.w = 1.0
+        self.spawner(request)
+        return []
 
 if __name__ == "__main__":
     rospy.init_node('sprayer')
-    m2s = Sprayer()
-    #m2s.spray()
-    #m2s.load_file('test.yaml')
-    #m2s._create_svg()
-    #m2s.write_svg()
+    Sprayer()
     rospy.spin()


### PR DESCRIPTION
I created 7 spray modules. Now instead of one service call (eg rosservice call /thorvald_001/spray) we can call seven different services for each spray module created (e.g.  rosservice call /thorvald_001/spray1,  rosservice call /thorvald_001/spray2 etc.).
The services spray from 0.3 to -0.3, from the center of the sprayer, with step 0.1 (0.3 = 0.3 to the left and -0.3 = 0.3 to the right of the sprayer).
For instance, the first service (thorvald_001/spray1) sprays 0.3 left from the center of the sprayer,  the fourth service (thorvald_001/spray4) sprays on top of the sprayers position and the seventh service sprays 0.3 right of the center of the sprayer.